### PR TITLE
Fix a bug where the description of a selected event was not populated when creating an Events List.

### DIFF
--- a/addon/globalPlugins/evtTracker.py
+++ b/addon/globalPlugins/evtTracker.py
@@ -267,6 +267,9 @@ class EventsListDialog(
 				eventInfo = ";\n".join([event.info[1], event.info[2]] + event.info[4:])
 				self.list.Append(f"{eventType}; {eventInfo}")
 			self.list.SetSelection(0)
+			event = wx.CommandEvent(wx.EVT_LISTBOX.typeId, self.list.GetId())
+			event.SetEventObject(self.list)
+			self.list.ProcessEvent(event)
 
 	def onListItemSelected(self, event):
 		index = event.GetSelection()


### PR DESCRIPTION
Because `SetSelection` does not trigger events, a code snippet was added in the function that creates the list to manually trigger the `EVT_LISTBOX` event.