### PR TITLE
The way to add a browseable event description

### DIFF
--- a/addon/globalPlugins/evtTracker.py
+++ b/addon/globalPlugins/evtTracker.py
@@ -16,6 +16,7 @@ from NVDAObjects.UIA import UIA
 import NVDAObjects
 from scriptHandler import script
 import wx
+import ui
 
 
 # Security: disable the global plugin altogether in secure mode.
@@ -242,6 +243,7 @@ class EventsListDialog(
 			style=wx.LB_SINGLE
 		)
 		self.list.Bind(wx.EVT_LISTBOX, self.onListItemSelected)
+		self.list.Bind(wx.EVT_LISTBOX_DCLICK, self.onListItemDClick)
 		contentsSizer.Add(self.list, flag=wx.EXPAND)
 		contentsSizer.AddSpacer(gui.guiHelper.SPACE_BETWEEN_VERTICAL_DIALOG_ITEMS)
 		self.description = gui.guiHelper.LabeledControlHelper(
@@ -273,3 +275,9 @@ class EventsListDialog(
 		nvdaEvent = self.eventHistory[index] if index >= 0 else None
 		if nvdaEvent:
 			self.description.control.Value = "\n".join(nvdaEvent.info)
+
+	def onListItemDClick(self, event):
+		index = event.GetSelection()
+		nvdaEvent = self.eventHistory[index] if index >= 0 else None
+		if nvdaEvent:
+			ui.browseableMessage("\n".join(nvdaEvent.info), nvdaEvent.type)


### PR DESCRIPTION
Added a double-click event to the event list, using `ui.browseableMessage` to directly display the event description, making it easier to browse.

Question:

- Add a way to trigger this feature using the `enter` key